### PR TITLE
Keep movies view within viewable space

### DIFF
--- a/app/layouts/home_layout.rb
+++ b/app/layouts/home_layout.rb
@@ -41,6 +41,7 @@ class HomeLayout < MK::Layout
     top 200
     left 0
     right "100%"
+    height "100% - 200"
   end
 
 end


### PR DESCRIPTION
As it stands, the bounds of the scroll area go 200px off the screen due to the "top" being 200 and an implied height of 100%
